### PR TITLE
feat: add support for negated settings

### DIFF
--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -94,8 +94,9 @@ parser = Lark(
 
         KEYWORD: /[a-z_]+/i
 
-        ?settings: string
-                 | LITERAL
+        settings: string
+                | "!" string   -> negated_settings
+                | LITERAL
 
         !string: /"([^;\\"]|(?!\\)\\[;\\"])*"/
 

--- a/parsuricata/rules.py
+++ b/parsuricata/rules.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
-from typing import Union, Any, List
+from typing import Any, List, Union
 
 __all__ = [
     'RulesList',
     'Rule',
     'Option',
     'Variable',
+    'Setting',
+    'NegatedSetting',
     'Negated',
     'PortRange',
     'Grouping',
@@ -46,7 +48,7 @@ class Rule:
 @dataclass
 class Option:
     keyword: str
-    settings: Any = None
+    settings: 'Setting' = None
 
     def __str__(self):
         if self.settings is None:
@@ -61,6 +63,21 @@ class Variable:
 
     def __str__(self):
         return f'${self.identifier}'
+
+
+class Setting(str):
+    @property
+    def is_negated(self):
+        return False
+
+
+class NegatedSetting(Setting):
+    @property
+    def is_negated(self):
+        return True
+
+    def __repr__(self):
+        return f'!{super().__repr__()}'
 
 
 @dataclass(frozen=True)

--- a/parsuricata/transformer.py
+++ b/parsuricata/transformer.py
@@ -1,9 +1,19 @@
-from ipaddress import ip_interface, ip_address
-from typing import Union, Any
+from ipaddress import ip_address, ip_interface
+from typing import Any, Union
 
-from lark import Token, InlineTransformer, Tree
+from lark import InlineTransformer, Token, Tree
 
-from .rules import RulesList, Rule, Option, Variable, Negated, PortRange, Grouping
+from .rules import (
+    Grouping,
+    Negated,
+    NegatedSetting,
+    Option,
+    PortRange,
+    Rule,
+    RulesList,
+    Setting,
+    Variable,
+)
 
 
 class RuleTransformer(InlineTransformer):
@@ -52,11 +62,17 @@ class RuleTransformer(InlineTransformer):
 
     def option(self, keyword: Token, settings: Union[Token, Tree] = None) -> Option:
         if settings is not None:
-            value = str(settings)
+            value = settings
         else:
             value = None
 
         return Option(str(keyword), value)
+
+    def settings(self, value: Any):
+        return Setting(value)
+
+    def negated_settings(self, value: Any):
+        return NegatedSetting(value)
 
     def variable(self, variable: Token):
         identifier = str(variable)[1:]

--- a/test_parsuricata.py
+++ b/test_parsuricata.py
@@ -1,1 +1,33 @@
-# TODO
+from parsuricata import parse_rules
+
+
+def test_content():
+    rules = parse_rules('''
+        alert ip any any -> any any (content: "heymum";)
+    ''')
+
+    assert len(rules) == 1
+
+    rule = rules[0]
+    assert len(rule.options) == 1
+
+    option = rule.options[0]
+    assert option.settings == 'heymum'
+    assert not option.settings.is_negated
+    assert repr(option.settings) == "'heymum'"
+
+
+def test_negated_content():
+    rules = parse_rules('''
+        alert ip any any -> any any (content: !"heymum";)
+    ''')
+
+    assert len(rules) == 1
+
+    rule = rules[0]
+    assert len(rule.options) == 1
+
+    option = rule.options[0]
+    assert option.settings == 'heymum'
+    assert option.settings.is_negated
+    assert repr(option.settings) == "!'heymum'"


### PR DESCRIPTION
Add basic support for negated option settings, e.g.
```
alert ip any any -> any any (content: !"heymum";)
```

Here's a test to demonstrate usage:
```py
def test_negated_content():
    rules = parse_rules('''
        alert ip any any -> any any (content: !"heymum";)
    ''')

    assert len(rules) == 1

    rule = rules[0]
    assert len(rule.options) == 1

    option = rule.options[0]
    assert option.settings == 'heymum'
    assert option.settings.is_negated
    assert repr(option.settings) == "!'heymum'"
```