### PR TITLE
Allow escaped newlines before first option

### DIFF
--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -87,7 +87,7 @@ parser = Lark(
         !direction: "->"
                   | "<>"
 
-        body: (option _ESCAPED_NEWLINE*)+
+        body: _ESCAPED_NEWLINE* (option _ESCAPED_NEWLINE*)+
 
         option: KEYWORD ";"
               | KEYWORD ":" settings ";"

--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -1,106 +1,108 @@
 from lark import Lark
 
 
+grammar = r'''
+    %ignore " "
+
+    _NEWLINE: /[\r\n]+/
+    _ESCAPED_NEWLINE: /(\\(\r\n|\r|\n))+/
+
+    rules: _NEWLINE* rule _NEWLINE*
+         | _NEWLINE* rule (_NEWLINE+ rule)+ _NEWLINE*
+
+    rule: action protocol target port direction target port "(" body ")"
+
+    !action: "pass"
+           | "drop"
+           | "reject"
+           | "alert"
+
+    !protocol: "ip"
+             | "tcp"
+             | "udp"
+             | "icmp"
+             | "http"
+             | "ftp"
+             | "tls"
+             | "smb"
+             | "dns"
+             | "dcerpc"
+             | "ssh"
+             | "smtp"
+             | "imap"
+             | "msn"
+             | "modbus"
+             | "dnp3"
+             | "enip"
+             | "nfs"
+             | "ikev2"
+             | "krb5"
+             | "ntp"
+             | "dhcp"
+
+    ?target: any
+           | target_spec
+
+    !any: "any"
+
+    ?target_spec: variable
+                | ip
+                | cidr
+                | "[" target_spec ("," target_spec)* "]"
+                | "!" target_spec                           -> negated
+
+    variable: /\$[a-z_]+/i
+
+    ip: ip_v4
+      | ip_v6
+
+    ?ip_v4: /\b(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b/
+    ?ip_v6: /\b(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\b/
+
+    cidr: cidr_v4
+        | cidr_v6
+
+    ?cidr_v4: /\b(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))\b/
+    ?cidr_v6: /\b(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(\/((1(1[0-9]|2[0-8]))|([0-9][0-9])|([0-9])))\b/
+
+    ?port: any
+         | port_spec
+
+    ?port_spec: variable
+              | integer
+              | "[" port_grouping_spec ("," port_grouping_spec)* "]"    -> port_grouping
+              | "!" port_spec                                           -> negated
+
+    ?port_grouping_spec: port_spec
+                       | port_range
+
+    !port_range: integer ":" integer
+               | ":" integer
+               | integer ":"
+
+    integer: /\d+/
+
+    !direction: "->"
+              | "<>"
+
+    body: _ESCAPED_NEWLINE* (option _ESCAPED_NEWLINE*)+
+
+    option: KEYWORD ";"
+          | KEYWORD ":" settings ";"
+
+    KEYWORD: /[a-z_]+/i
+
+    settings: string
+            | "!" string   -> negated_settings
+            | LITERAL
+
+    !string: /"([^;\\"]|(?!\\)\\[;\\"])*"/
+
+    LITERAL: /(?!\s+)([^;\\"]|(?!\\)\\[;\\"])+(?!\s+)/
+'''
+
 parser = Lark(
     start='rules',
-    grammar=r'''
-        %ignore " "
-
-        _NEWLINE: /[\r\n]+/
-        _ESCAPED_NEWLINE: /(\\(\r\n|\r|\n))+/
-
-        rules: _NEWLINE* rule _NEWLINE*
-             | _NEWLINE* rule (_NEWLINE+ rule)+
-
-        rule: action protocol target port direction target port "(" body ")"
-
-        !action: "pass"
-               | "drop"
-               | "reject"
-               | "alert"
-
-        !protocol: "ip"
-                 | "tcp"
-                 | "udp"
-                 | "icmp"
-                 | "http"
-                 | "ftp"
-                 | "tls"
-                 | "smb"
-                 | "dns"
-                 | "dcerpc"
-                 | "ssh"
-                 | "smtp"
-                 | "imap"
-                 | "msn"
-                 | "modbus"
-                 | "dnp3"
-                 | "enip"
-                 | "nfs"
-                 | "ikev2"
-                 | "krb5"
-                 | "ntp"
-                 | "dhcp"
-
-        ?target: any
-               | target_spec
-
-        !any: "any"
-
-        ?target_spec: variable
-                    | ip
-                    | cidr
-                    | "[" target_spec ("," target_spec)* "]"
-                    | "!" target_spec                           -> negated
-
-        variable: /\$[a-z_]+/i
-
-        ip: ip_v4
-          | ip_v6
-
-        ?ip_v4: /\b(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b/
-        ?ip_v6: /\b(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\b/
-
-        cidr: cidr_v4
-            | cidr_v6
-
-        ?cidr_v4: /\b(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))\b/
-        ?cidr_v6: /\b(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(\/((1(1[0-9]|2[0-8]))|([0-9][0-9])|([0-9])))\b/
-
-        ?port: any
-             | port_spec
-
-        ?port_spec: variable
-                  | integer
-                  | "[" port_grouping_spec ("," port_grouping_spec)* "]"    -> port_grouping
-                  | "!" port_spec                                           -> negated
-
-        ?port_grouping_spec: port_spec
-                           | port_range
-
-        !port_range: integer ":" integer
-                   | ":" integer
-                   | integer ":"
-
-        integer: /\d+/
-
-        !direction: "->"
-                  | "<>"
-
-        body: _ESCAPED_NEWLINE* (option _ESCAPED_NEWLINE*)+
-
-        option: KEYWORD ";"
-              | KEYWORD ":" settings ";"
-
-        KEYWORD: /[a-z_]+/i
-
-        settings: string
-                | "!" string   -> negated_settings
-                | LITERAL
-
-        !string: /"([^;\\"]|(?!\\)\\[;\\"])*"/
-
-        LITERAL: /(?!\s+)([^;\\"]|(?!\\)\\[;\\"])+(?!\s+)/
-
-    '''
+    parser='lalr',
+    grammar=grammar,
 )

--- a/test_parsuricata.py
+++ b/test_parsuricata.py
@@ -31,3 +31,21 @@ def test_negated_content():
     assert option.settings == 'heymum'
     assert option.settings.is_negated
     assert repr(option.settings) == "!'heymum'"
+
+
+def test_multiline_rules():
+    rules = parse_rules('''
+        alert ip any any -> any any ( \\
+            content: "heymum"; \\
+        )
+    ''')
+
+    assert len(rules) == 1
+
+    rule = rules[0]
+    assert len(rule.options) == 1
+
+    option = rule.options[0]
+    assert option.settings == 'heymum'
+    assert not option.settings.is_negated
+    assert repr(option.settings) == "'heymum'"

--- a/test_parsuricata.py
+++ b/test_parsuricata.py
@@ -33,7 +33,7 @@ def test_negated_content():
     assert repr(option.settings) == "!'heymum'"
 
 
-def test_multiline_rules():
+def test_multiline_rule():
     rules = parse_rules('''
         alert ip any any -> any any ( \\
             content: "heymum"; \\
@@ -49,3 +49,36 @@ def test_multiline_rules():
     assert option.settings == 'heymum'
     assert not option.settings.is_negated
     assert repr(option.settings) == "'heymum'"
+
+
+def test_multiple_rules():
+    rules = parse_rules('''
+        alert ip any any -> any any (content: "a";)
+        alert ip any any -> any any ( content: "b"; \\
+        )
+        alert ip any any -> any any ( \\
+            content: "c"; \\
+        )
+        alert ip any any -> any any (content: !"d";)
+        alert ip any any -> any any ( content: !"e"; \\
+        )
+        alert ip any any -> any any ( \\
+            \\
+            content: !"f"; \\
+        )
+    ''')
+
+    expected = [
+        ('a', False),
+        ('b', False),
+        ('c', False),
+        ('d', True),
+        ('e', True),
+        ('f', True),
+    ]
+    actual = [
+        (option.settings, option.settings.is_negated)
+        for rule in rules
+        for option in rule.options
+    ]
+    assert expected == actual


### PR DESCRIPTION
The current parser only allows escaped newlines after each option, but not before the first option. This means it can handle rules like these:

```snort
alert tcp $HOME_NET any -> $EXTERNAL_NET any ( msg:"Stuff!"; \\
  content:"abc"; )

alert tcp $HOME_NET any -> $EXTERNAL_NET any ( msg:"Stuff!"; \\
  content:"abc"; \\
)

alert tcp $HOME_NET any -> $EXTERNAL_NET any ( msg:"Stuff!"; \\
  \\
  \\
  content:"abc"; \\
)
```

But not this:
```snort
alert tcp $HOME_NET any -> $EXTERNAL_NET any ( \\
  msg:"Stuff!"; \\
  content:"abc"; \\
)
```

This PR allows newlines to be written before the first option.

Additionally, this PR allows newlines at the end of the file, which apparently have never worked, or #2 broke it.