### PR TITLE
fix: properly support escape sequences in setting strings

### DIFF
--- a/parsuricata/__init__.py
+++ b/parsuricata/__init__.py
@@ -6,5 +6,4 @@ from .transformer import RuleTransformer
 
 
 def parse_rules(source: str) -> RulesList:
-    tree = parser.parse(source)
-    return RuleTransformer().transform(tree)
+    return parser.parse(source)

--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -8,8 +8,7 @@ grammar = r'''
     _NEWLINE: /[\r\n]+/
     _ESCAPED_NEWLINE: /(\\(\r\n|\r|\n))+/
 
-    rules: _NEWLINE* rule _NEWLINE*
-         | _NEWLINE* rule (_NEWLINE+ rule)+ _NEWLINE*
+    rules: (_NEWLINE* rule)* _NEWLINE*
 
     rule: action protocol target port direction target port "(" body ")"
 

--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -2,6 +2,7 @@ from lark import Lark
 
 
 grammar = r'''
+    %import common.ESCAPED_STRING   -> STRING
     %ignore " "
 
     _NEWLINE: /[\r\n]+/
@@ -96,7 +97,7 @@ grammar = r'''
             | "!" string   -> negated_settings
             | LITERAL
 
-    !string: /"([^;\\"]|(?!\\)\\[;\\"])*"/
+    string: STRING
 
     LITERAL: /(?!\s+)([^;\\"]|(?!\\)\\[;\\"])+(?!\s+)/
 '''

--- a/parsuricata/_parser.py
+++ b/parsuricata/_parser.py
@@ -1,5 +1,6 @@
 from lark import Lark
 
+from .transformer import RuleTransformer
 
 grammar = r'''
     %import common.ESCAPED_STRING   -> STRING
@@ -105,4 +106,5 @@ parser = Lark(
     start='rules',
     parser='lalr',
     grammar=grammar,
+    transformer=RuleTransformer(),
 )

--- a/test_parsuricata.py
+++ b/test_parsuricata.py
@@ -112,3 +112,19 @@ def test_escaped(setting, expected):
     ]
     actual = rules
     assert expected == actual
+
+
+def test_spaces_at_ends_of_string():
+    rules = parse_rules(f'''
+        alert ip any any -> any any ( \\
+            msg: " This is a test of spaces. "; \\
+        )
+    ''')
+
+    expected = [
+        Rule('alert', 'ip', 'any', 'any', '->', 'any', 'any', [
+            Option('msg', Setting(' This is a test of spaces. '))
+        ])
+    ]
+    actual = rules
+    assert expected == actual


### PR DESCRIPTION
This PR uses a better escaped string regex terminal, which properly supports escape sequences. This terminal is imported in the grammar from Lark's library, and is defined as:
```ebnf
_STRING_INNER: /.*?/
_STRING_ESC_INNER: _STRING_INNER /(?<!\\)(\\\\)*?/

ESCAPED_STRING : "\"" _STRING_ESC_INNER "\""
```
Which it says is roughly equivalent to the regex: `".*?(?<!\\)"`. See https://github.com/lark-parser/lark/blob/3b2bf47dc4750add61df4e236238a626b79d3da0/docs/json_tutorial.md#part-1---the-grammar

A number of test cases have been added to ensure it works.

---

Also, in this PR I simplified the grammar just a smidge, and passed the `transformer` directly to the parser, which the [Lark docs](https://lark-parser.readthedocs.io/en/latest/json_tutorial.html#step-3-tree-less-lalr-1) say "[avoids] building the parse tree, and just [sends] the data straight into our transformer" — which apparently improves performance and memory efficiency.

I really ought to add a large corpus of rules to the tests to benchmark.