### PR TITLE
Basic attempt for compatibility with lark-parser >=1.2

### DIFF
--- a/parsuricata/transformer.py
+++ b/parsuricata/transformer.py
@@ -1,7 +1,7 @@
 from ipaddress import ip_address, ip_interface
 from typing import Any, Union
 
-from lark import InlineTransformer, Token, Tree
+from lark import Transformer, v_args, Tree, Token
 
 from .rules import (
     Grouping,
@@ -19,7 +19,8 @@ from .rules import (
 )
 
 
-class RuleTransformer(InlineTransformer):
+@v_args(inline=True)
+class RuleTransformer(Transformer):
     str = str
 
     def rules(self, *rules):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Issues = 'https://github.com/theY4Kman/parsuricata/issues'
 
 [tool.poetry.dependencies]
 python = '^3.6'
-lark-parser = '^0.12.0'
+lark-parser = '>1.2.x'
 
 [tool.poetry.dev-dependencies]
 pytest = '^6.2'


### PR DESCRIPTION
Since the last commits to Parsuricata the developers of lark-parser have made a lot of new releases some of which are incompatible with parsuricata.

It looks like the changes required to support lark-parser >=1.2 aren't all that significant, or at least all the tests still pass with the changes in this PR.

